### PR TITLE
Tf distributed

### DIFF
--- a/mnist-distributed/mirrored_mnist.py
+++ b/mnist-distributed/mirrored_mnist.py
@@ -30,7 +30,8 @@ def data_loader(hyperparams):
     )
     
 def model_with_strategy(learning_rate):
-    strategy = tf.distribute.MirroredStrategy()
+    gpus = tf.config.list_logical_devices('GPU')
+    strategy = tf.distribute.MirroredStrategy(gpus)
     with strategy.scope():
         model = keras.Sequential(
                 [

--- a/mnist-distributed/mirrored_mnist.py
+++ b/mnist-distributed/mirrored_mnist.py
@@ -6,6 +6,7 @@ import gzip, pickle, os
 import numpy as np
 import tensorflow as tf
 import argparse
+import ast
 
 MODEL_DIR = "/model/"
 input_shape = (28, 28, 1)

--- a/mnist-distributed/mirrored_mnist.py
+++ b/mnist-distributed/mirrored_mnist.py
@@ -11,6 +11,8 @@ MODEL_DIR = "/model/"
 input_shape = (28, 28, 1)
 num_classes = 10
 
+TF_CONFIG = os.environ.get('TF_CONFIG')
+
 def data_loader(hyperparams):
     f = gzip.open('/mnist/mnist.pkl.gz', 'rb')
     dataset = pickle.load(f, encoding='bytes')

--- a/mnist-distributed/mirrored_mnist.py
+++ b/mnist-distributed/mirrored_mnist.py
@@ -31,8 +31,7 @@ def data_loader(hyperparams):
     
 def model_with_strategy(learning_rate):
     gpus = tf.config.list_logical_devices('GPU')
-    if TF_CONFIG and ast.literal_eval(TF_CONFIG)['task']['type'] != 'ps':
-        strategy = tf.distribute.MirroredStrategy(gpus)
+    strategy = tf.distribute.MirroredStrategy(gpus)
     with strategy.scope():
         model = keras.Sequential(
                 [
@@ -58,7 +57,7 @@ class DistributedTraining(object):
         
     def train(self):
         if TF_CONFIG and ast.literal_eval(TF_CONFIG)['task']['type'] != 'ps':
-            model = model_with_strategy(self.learning_rate)i
+            model = model_with_strategy(self.learning_rate)
             #steps per epoch are reduced here to train on limited resources
             #you are free to remove this argument
             history = model.fit(self.train_dataset, 


### PR DESCRIPTION
 fix to pass gpus to strategy if found. Fixes warning WARNING:tensorlow:There are non-GPU devices in `tf.distribute.Strategy`, not using nccl allreduce.